### PR TITLE
Add "mps" detection and device_type to support running on Apple Silicon

### DIFF
--- a/gradio/inference.py
+++ b/gradio/inference.py
@@ -13,6 +13,8 @@ Note_list = Note_list + ['z', 'x']
 
 if torch.cuda.is_available():
     device = torch.device("cuda")
+elif torch.backends.mps.is_available():
+    device = torch.device("mps")
 else:
     device = torch.device("cpu")
 


### PR DESCRIPTION
Add support for Apple Silicon "mps" device_type.
NOTE: requires installing Apples' PyTorch libraries per https://developer.apple.com/metal/pytorch/ 