### PR TITLE
Update utils.py to avoid numpy error

### DIFF
--- a/RL/utils.py
+++ b/RL/utils.py
@@ -3,6 +3,7 @@ import random
 import bisect
 import json
 import re
+import numpy as np
 from config import *
 from transformers import GPT2Model, GPT2LMHeadModel, LlamaModel, LlamaForCausalLM, PreTrainedModel
 from samplings import top_p_sampling, top_k_sampling, temperature_sampling
@@ -310,6 +311,19 @@ class CharLevelDecoder(PreTrainedModel):
 
         return probs
 
+def safe_normalize_probs(probs):
+    epsilon = 1e-12
+    probs = np.array(probs, dtype=np.float64)
+    probs = np.where(np.isnan(probs) | (probs < 0), 0, probs)
+    probs = probs + epsilon
+    s = probs.sum()
+    if s > 0:
+        probs = probs / s
+    else:
+        probs = np.zeros_like(probs)
+        probs[0] = 1.0
+    return probs
+
 class NotaGenLMHeadModel(PreTrainedModel):
     """
     NotaGen is a language model with a hierarchical structure.
@@ -372,8 +386,11 @@ class NotaGenLMHeadModel(PreTrainedModel):
 
         while True:
             prob = self.char_level_decoder.generate(encoded_patches[0][-1], tokens).cpu().detach().numpy()  # [128]
+            prob = safe_normalize_probs(prob)
             prob = top_k_sampling(prob, top_k=top_k, return_probs=True) # [128]
+            prob = safe_normalize_probs(prob)
             prob = top_p_sampling(prob, top_p=top_p, return_probs=True) # [128]
+            prob = safe_normalize_probs(prob)
             token = temperature_sampling(prob, temperature=temperature) # int
             char = chr(token)
             generated_patch.append(token)

--- a/finetune/utils.py
+++ b/finetune/utils.py
@@ -3,6 +3,7 @@ import random
 import bisect
 import json
 import re
+import numpy as np
 from config import *
 from transformers import GPT2Model, GPT2LMHeadModel, LlamaModel, LlamaForCausalLM, PreTrainedModel
 from samplings import top_p_sampling, top_k_sampling, temperature_sampling
@@ -330,6 +331,19 @@ class CharLevelDecoder(PreTrainedModel):
 
         return probs
 
+def safe_normalize_probs(probs):
+    epsilon = 1e-12
+    probs = np.array(probs, dtype=np.float64)
+    probs = np.where(np.isnan(probs) | (probs < 0), 0, probs)
+    probs = probs + epsilon
+    s = probs.sum()
+    if s > 0:
+        probs = probs / s
+    else:
+        probs = np.zeros_like(probs)
+        probs[0] = 1.0
+    return probs
+
 class NotaGenLMHeadModel(PreTrainedModel):
     """
     NotaGen is a language model with a hierarchical structure.
@@ -392,8 +406,11 @@ class NotaGenLMHeadModel(PreTrainedModel):
 
         while True:
             prob = self.char_level_decoder.generate(encoded_patches[0][-1], tokens).cpu().detach().numpy()  # [128]
+            prob = safe_normalize_probs(prob)
             prob = top_k_sampling(prob, top_k=top_k, return_probs=True) # [128]
+            prob = safe_normalize_probs(prob)
             prob = top_p_sampling(prob, top_p=top_p, return_probs=True) # [128]
+            prob = safe_normalize_probs(prob)
             token = temperature_sampling(prob, temperature=temperature) # int
             char = chr(token)
             generated_patch.append(token)

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -3,6 +3,7 @@ import random
 import bisect
 import json
 import re
+import numpy as np
 from config import *
 from transformers import GPT2Model, GPT2LMHeadModel, LlamaModel, LlamaForCausalLM, PreTrainedModel
 from samplings import top_p_sampling, top_k_sampling, temperature_sampling
@@ -330,6 +331,19 @@ class CharLevelDecoder(PreTrainedModel):
 
         return probs
 
+def safe_normalize_probs(probs):
+    epsilon = 1e-12  # Smallest value to avoid log(0) and maintain precision
+    probs = np.array(probs, dtype=np.float64)
+    probs = np.where(np.isnan(probs) | (probs < 0), 0, probs)
+    probs = probs + epsilon  # Ensure strictly positive
+    s = probs.sum()
+    if s > 0:
+        probs = probs / s
+    else:
+        probs = np.zeros_like(probs)
+        probs[0] = 1.0
+    return probs
+
 class NotaGenLMHeadModel(PreTrainedModel):
     """
     NotaGen is a language model with a hierarchical structure.
@@ -392,8 +406,11 @@ class NotaGenLMHeadModel(PreTrainedModel):
 
         while True:
             prob = self.char_level_decoder.generate(encoded_patches[0][-1], tokens).cpu().detach().numpy()  # [128]
+            prob = safe_normalize_probs(prob)
             prob = top_k_sampling(prob, top_k=top_k, return_probs=True) # [128]
+            prob = safe_normalize_probs(prob)
             prob = top_p_sampling(prob, top_p=top_p, return_probs=True) # [128]
+            prob = safe_normalize_probs(prob)
             token = temperature_sampling(prob, temperature=temperature) # int
             char = chr(token)
             generated_patch.append(token)

--- a/inference/utils.py
+++ b/inference/utils.py
@@ -3,6 +3,7 @@ import random
 import bisect
 import json
 import re
+import numpy as np
 from config import *
 from transformers import GPT2Model, GPT2LMHeadModel, LlamaModel, LlamaForCausalLM, PreTrainedModel
 from samplings import top_p_sampling, top_k_sampling, temperature_sampling
@@ -330,6 +331,19 @@ class CharLevelDecoder(PreTrainedModel):
 
         return probs
 
+def safe_normalize_probs(probs):
+    epsilon = 1e-12
+    probs = np.array(probs, dtype=np.float64)
+    probs = np.where(np.isnan(probs) | (probs < 0), 0, probs)
+    probs = probs + epsilon
+    s = probs.sum()
+    if s > 0:
+        probs = probs / s
+    else:
+        probs = np.zeros_like(probs)
+        probs[0] = 1.0
+    return probs
+
 class NotaGenLMHeadModel(PreTrainedModel):
     """
     NotaGen is a language model with a hierarchical structure.
@@ -392,8 +406,11 @@ class NotaGenLMHeadModel(PreTrainedModel):
 
         while True:
             prob = self.char_level_decoder.generate(encoded_patches[0][-1], tokens).cpu().detach().numpy()  # [128]
+            prob = safe_normalize_probs(prob)
             prob = top_k_sampling(prob, top_k=top_k, return_probs=True) # [128]
+            prob = safe_normalize_probs(prob)
             prob = top_p_sampling(prob, top_p=top_p, return_probs=True) # [128]
+            prob = safe_normalize_probs(prob)
             token = temperature_sampling(prob, temperature=temperature) # int
             char = chr(token)
             generated_patch.append(token)

--- a/pretrain/utils.py
+++ b/pretrain/utils.py
@@ -3,6 +3,7 @@ import random
 import bisect
 import json
 import re
+import numpy as np
 from config import *
 from transformers import GPT2Model, GPT2LMHeadModel, LlamaModel, LlamaForCausalLM, PreTrainedModel
 from samplings import top_p_sampling, top_k_sampling, temperature_sampling
@@ -328,6 +329,19 @@ class CharLevelDecoder(PreTrainedModel):
 
         return probs
 
+def safe_normalize_probs(probs):
+    epsilon = 1e-12
+    probs = np.array(probs, dtype=np.float64)
+    probs = np.where(np.isnan(probs) | (probs < 0), 0, probs)
+    probs = probs + epsilon
+    s = probs.sum()
+    if s > 0:
+        probs = probs / s
+    else:
+        probs = np.zeros_like(probs)
+        probs[0] = 1.0
+    return probs
+
 class NotaGenLMHeadModel(PreTrainedModel):
     """
     NotaGen is a language model with a hierarchical structure.
@@ -390,8 +404,11 @@ class NotaGenLMHeadModel(PreTrainedModel):
 
         while True:
             prob = self.char_level_decoder.generate(encoded_patches[0][-1], tokens).cpu().detach().numpy()
+            prob = safe_normalize_probs(prob)
             prob = top_k_sampling(prob, top_k=top_k, return_probs=True)
+            prob = safe_normalize_probs(prob)
             prob = top_p_sampling(prob, top_p=top_p, return_probs=True)
+            prob = safe_normalize_probs(prob)
             token = temperature_sampling(prob, temperature=temperature)
             char = chr(token)
             generated_patch.append(token)


### PR DESCRIPTION
Every time I would run NotaGen using the latest numpy v2, and some other times on v1, I would get an error on the terminal from the samplings library that "Probabilities do not sum to 1" for a numpy function. I researched this and found out we need to modify the probabilities before handing them off the the samplings library. I tested this for the gradio/utils.py file and I don't get the error anymore at all without noticing any generation errors, so this seems to fix the crashes!

Let me know if you want me to modify this in any way.